### PR TITLE
force katex/formulas to be same size as surrounding text

### DIFF
--- a/assets/static/css/content.css
+++ b/assets/static/css/content.css
@@ -69,3 +69,7 @@ blockquote:before {
   color: red !important;
   cursor: pointer;
 }
+
+.katex {
+  font-size: 1em !important;
+}

--- a/assets/static/css/site.css
+++ b/assets/static/css/site.css
@@ -52,7 +52,3 @@ p {
 .project-navigation {
   text-align: center;
 }
-
-.katex {
-  font-size: 1em;
-}


### PR DESCRIPTION
- `!important` was added to katex css rule, to force it to be the same size as surrounding text
- css rule was moved from `site.css` to `content.css`