### PR TITLE
feature: implement collapsable references

### DIFF
--- a/assets/static/css/references.js
+++ b/assets/static/css/references.js
@@ -1,0 +1,12 @@
+var toggle = document.getElementById('references-toggle')
+if (!!toggle) {
+  var list = document.getElementById('references-list')
+  toggle.onclick = function () {
+    var current = list.style.display
+    var newDisplay = list.style.display === 'none' ? 'block' : 'none'
+    var label = list.style.display === 'none' ? 'hide' : 'show'
+    list.style.display = newDisplay
+    toggle.innerText = label
+    return false
+  }
+}

--- a/templates/macros/references.html
+++ b/templates/macros/references.html
@@ -1,13 +1,17 @@
 {% macro references(refs, title='References') -%}
   {% if refs.blocks|length > 0 %}
+  {% set hide = refs.blocks|length > 10 %}
   <div class="row mt-5">
     <div class="col-md-12">
-      <h3>{{ title }}</h3>
-      <ol name="references">
-        {% for reference in refs.blocks %}
-        {{ reference }}
-        {% endfor %}
-      </ol>
+      <h3>{{ title }} {% if hide %}(<a href="#" id="references-toggle">show</a>){% endif %}</h3>
+      <div id="references-list">
+        <ol name="references">
+          {% for reference in refs.blocks %}
+          {{ reference }}
+          {% endfor %}
+        </ol>
+      </div>
+      {% if hide %}<script>document.getElementById('references-list').style.display = 'none'</script>{% endif %} {# do this is js so that if the browser doesn't have js enabled, it will still show #}
     </div>
   </div>
   {% endif %}
@@ -16,4 +20,5 @@
   <script>
     var referenceData = {{ refs.blocks|refs_format|tojson }}
   </script>
+  <script src="{{ '/static/js/references.js'|asseturl }}"></script>
 {%- endmacro %}


### PR DESCRIPTION
- if there are more than 10 references, they will be collapsed initially, and can be toggled
- the initial hiding is done via javascript, as this means that browsers with js disabled will see the entire list, rather than being stuck with the hidden list they can't toggle