### PR TITLE
fix: societies model file and templates had incorrect name field

### DIFF
--- a/models/society.ini
+++ b/models/society.ini
@@ -7,7 +7,7 @@ label = Update
 type = string
 width = 1/2
 
-[fields.title]
+[fields.name]
 label = Title
 type = string
 width = 1/2

--- a/templates/society.html
+++ b/templates/society.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% block title %}{{ this.title }}{% endblock %}
+{% block title %}{{ this.name }}{% endblock %}
 {% block body %}
 
 <div class="row">

--- a/templates/societyindex.html
+++ b/templates/societyindex.html
@@ -7,7 +7,7 @@
     <h1>Societies Index</h1>
     <ul>
     {% for page in site.query('/Societies') %}
-      <li><a href="{{ page|url }}">{{ page.title }}</a></li>
+      <li><a href="{{ page|url }}">{{ page.name }}</a></li>
     {% endfor %}
     </ul>
   </div>


### PR DESCRIPTION
As per https://github.com/davidferguson/mactutor-converter/commit/ef112f693a9a327ac55b37bab2ee82c6eb164603, the `societies` model should have a `name` field, rather than `titlename`. However this was incorrectly specified (in both the model and associated templates) as `title`.