### PR TITLE
fix: workaround for empty flow bug in lektor

### DIFF
--- a/templates/biography.html
+++ b/templates/biography.html
@@ -46,7 +46,7 @@
     <div class="row" style="text-align: center;">
       {{ thumbnail.thumbnail(this.attachments.images, True, this.path) }}
     </div>
-    {% if this.quotations.blocks|length > 0 %}
+    {% if this.quotations and this.quotations.blocks|length > 0 %}
     <div class="row mt-2" style="text-align: center;">
       <a href="{{ '%s/@quotations'|format(this.path)|url }}" style="width: 100%;">Quotations by {{ this.shortname }}</a>
     </div>
@@ -68,7 +68,7 @@
 {% import 'macros/additional.html' as additional %}
 {{ additional.additional(this.additional, this.otherweb, this.shortname) }}
 
-{% if this.honours.blocks|length > 0 %}
+{% if this.honours and this.honours.blocks|length > 0 %}
 <div class="row">
   <div class="col-md-12">
     <h3>Honours</h3>

--- a/templates/chronologyindex.html
+++ b/templates/chronologyindex.html
@@ -8,9 +8,11 @@
     {% for chronologyyear in site.query('/Chronology').include_undiscoverable(True).order_by('year') %}
     <h4>{{ chronologyyear.year }}</h4>
     <ul>
+      {% if chronologyyear.events %}
       {% for event in chronologyyear.events.blocks %}
       {{ event }}
       {% endfor %}
+      {% endif %}
     </ul>
     {% endfor %}
   </div>

--- a/templates/curve.html
+++ b/templates/curve.html
@@ -19,9 +19,11 @@
   </div>
 
   <div class="col-md-6">
+    {% if this.equations %}
     {% for equation in this.equations.blocks %}
     {{ equation }}
     {% endfor %}
+    {% endif %}
   </div>
 </div>
 

--- a/templates/macros/additional.html
+++ b/templates/macros/additional.html
@@ -1,11 +1,11 @@
 {% macro additional(additionals, otherwebs, name) -%}
-  {% if (additionals.blocks|length > 0) or (otherwebs.blocks|length > 0) %}
+  {% if (additionals and additionals.blocks|length > 0) or (otherwebs and otherwebs.blocks|length > 0) %}
   <div class="row">
     <div class="col-md-12">
       <h3>Additional Resources</h3>
     </div>
 
-    {% if (additionals.blocks|length > 0) %}
+    {% if (additionals and additionals.blocks|length > 0) %}
     <div class="col-md-6">
       <p>Other pages about {{ name }}:</p>
       <ol name="additional">
@@ -16,7 +16,7 @@
     </div>
     {% endif %}
 
-    {% if (otherwebs.blocks|length > 0) %}
+    {% if (otherwebs and otherwebs.blocks|length > 0) %}
     <div class="col-md-6">
       <p>Other pages in around the web about {{ name }}:</p>
       <ol name="otherweb">

--- a/templates/macros/references.html
+++ b/templates/macros/references.html
@@ -1,5 +1,5 @@
 {% macro references(refs, title='References') -%}
-  {% if refs.blocks|length > 0 %}
+  {% if refs and refs.blocks|length > 0 %}
   {% set hide = refs.blocks|length > 10 %}
   <div class="row mt-5">
     <div class="col-md-12">

--- a/templates/page.html
+++ b/templates/page.html
@@ -3,7 +3,7 @@
 {% block body %}
 
 <div class="row">
-  {% if this.sidebar.blocks|length > 0 %}
+  {% if this.sidebar and this.sidebar.blocks|length > 0 %}
   <div class="col-md-8">
   {% else %}
   <div class="col-md-12">
@@ -23,7 +23,7 @@
 
   </div>
 
-  {% if this.sidebar.blocks|length > 0 %}
+  {% if this.sidebar and this.sidebar.blocks|length > 0 %}
   <aside class="col-md-4">
     <div class="p-3 mb-3 bg-light rounded">
       <ol class="list-unstyled">

--- a/templates/plugins/chronologycategory.html
+++ b/templates/plugins/chronologycategory.html
@@ -14,9 +14,11 @@
     {% for chronologyyear in this.chronology %}
     <h4>{{ chronologyyear.year }}</h4>
     <ul>
+      {% if chronologyyear.events %}
       {% for event in chronologyyear.events.blocks %}
       {{ event }}
       {% endfor %}
+      {% endif %}
     </ul>
     {% endfor %}
   </div>

--- a/templates/plugins/curvesapplet.html
+++ b/templates/plugins/curvesapplet.html
@@ -32,9 +32,11 @@
   </div>
 
   <div class="col-md-6">
+    {% if this.parent.equations %}
     {% for equation in this.parent.equations.blocks %}
     {{ equation }}
     {% endfor %}
+    {% endif %}
   </div>
 </div>
 

--- a/templates/plugins/quotations.html
+++ b/templates/plugins/quotations.html
@@ -12,9 +12,11 @@
 
 <div class="row">
   <div class="col-md-12">
+    {% if this.parent.quotations %}
     {% for quote in this.parent.quotations.blocks %}
     {{ quote }}
     {% endfor %}
+    {% endif %}
   </div>
 </div>
 

--- a/templates/project.html
+++ b/templates/project.html
@@ -12,7 +12,7 @@
 
 <div class="row mt-5">
   <div class="col-md-12">
-    {% if this.pages.blocks|length > 0 %}
+    {% if this.pages and this.pages.blocks|length > 0 %}
     <h4>Contents</h4>
     <ol>
     {% for page in this.pages.blocks %}


### PR DESCRIPTION
There is a bug in lektor that when creating a new page with an empty flow field, it seems that field isn't written to the content file. Therefore, when it is referenced in the template (such as `{% if this.references.blocks|length > 0 %}`) this will give an error, as `this.references` is undefined and therefore doesn't have a `.blocks`.

The workaround for this is to check for the presence of the field before doing any flow operations on it. In the above example, this would become:

`{% if this.references and this.references.blocks|length > 0 %}`