### PR TITLE
make square backets non-italic, not m/k

### DIFF
--- a/assets/static/css/content.css
+++ b/assets/static/css/content.css
@@ -7,7 +7,7 @@
   font-weight: 400;
   font-display: swap;
   src: local('Nunito Sans Regular'), local('NunitoSans-Regular'), url(https://fonts.gstatic.com/s/nunitosans/v5/pe0qMImSLYBIv1o4X1M8cce9I9tAcVwo.woff2) format('woff2');
-  unicode-range: U+30-39, U+28-29, U+4B, U+4D, U+7B, U+7D;
+  unicode-range: U+30-39, U+28-29, U+5B, U+5D, U+7B, U+7D;
 }
 
 


### PR DESCRIPTION
fixes bug where letters M and K were set to non-italic, rather than [ and ]