### PR TITLE
fix: remove long names on footer

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -79,10 +79,11 @@
 
     <footer class="site-footer mt-3">
       <div class="row">
-        <div class="col-md-5">
-          MacTutor by <a href="http://www-groups.mcs.st-andrews.ac.uk/~john/">John J O'Connor</a> and <a href="http://www-groups.mcs.st-andrews.ac.uk/~edmund/">Edmund F Robertson</a>. View <a href="{{ '/license/'|url }}">full copyright information</a>.
+        <div class="col-md-4">
+          <a href="http://www-groups.mcs.st-andrews.ac.uk/~john/">JOC</a>/<a href="http://www-groups.mcs.st-andrews.ac.uk/~edmund/">EFR</a><br/>
+          <a href="{{ '/license/'|url }}">Copyright information</a>
         </div>
-        <div class="col-md-5">
+        <div class="col-md-6">
           School of Mathematics and Statistics
           <br/>
           University of St Andrews, Scotland


### PR DESCRIPTION
- change `John J O'Connor` to JOC
- change `Edmund F Robertson` to EFR
- make copyright box `col-md-4`, and maths dept box `col-md-6`