### PR TITLE
Give all fields default values

### DIFF
--- a/flowblocks/biographylink.ini
+++ b/flowblocks/biographylink.ini
@@ -7,19 +7,23 @@ label = Link Text
 description = How the link should appear on the Biography index
 type = string
 width = 2/6
+default =
 
 [fields.page]
 label = Page
 description = Which page this should link to. Give an absolute path, such as "/Societies/MA/#Langley"
 type = string
 width = 2/6
+default =
 
 [fields.birthyear]
 label = Birth Year
 type = integer
 width = 1/6
+default = 0
 
 [fields.deathyear]
 label = Death Year
 type = integer
 width = 1/6
+default = 0

--- a/flowblocks/bmcindexlink.ini
+++ b/flowblocks/bmcindexlink.ini
@@ -7,6 +7,7 @@ label = Link Text
 description = How the link should appear on the BMC index
 type = markup
 width = 1/4
+default =
 
 [fields.page]
 label = Biography
@@ -16,3 +17,4 @@ source = this.children
 item_key = {{ this._slug }}
 item_label = {{ this._slug }}
 width = 3/4
+default = 

--- a/flowblocks/bmcspeaker.ini
+++ b/flowblocks/bmcspeaker.ini
@@ -6,6 +6,7 @@ button_label = [[quote-right]]
 label = Name
 type = string
 width = 3/4
+default =
 
 [fields.mlink]
 label = Biography
@@ -15,7 +16,9 @@ source = site.query('/Biographies')
 item_key = {{ this._slug }}
 item_label = {{ this._slug }}
 width = 1/4
+default =
 
 [fields.talk]
 label = Title
 type = string
+default = 

--- a/flowblocks/bmcspeakertype.ini
+++ b/flowblocks/bmcspeakertype.ini
@@ -6,14 +6,17 @@ button_label = [[quote-right]]
 label = Title
 type = string
 width = 3/4
+default =
 
 [fields.type]
 label = Type
 type = select
 choices = Ap, Bm, Cs
 choice_labels = Plenary, Morning, Special
+default = Ap
 
 [fields.speakers]
 label = Speakers
 type = flow
 flow_blocks = bmcspeaker
+default =

--- a/flowblocks/chronology-event.ini
+++ b/flowblocks/chronology-event.ini
@@ -11,3 +11,4 @@ description = If the date is rough, check this box
 [fields.content]
 label = Event
 type = markup
+default = 

--- a/flowblocks/curveequation.ini
+++ b/flowblocks/curveequation.ini
@@ -5,7 +5,9 @@ button_label = [[quote-right]]
 [fields.type]
 label = Type
 type = string
+default =
 
 [fields.equation]
 label = Equation
 type = markup
+default = 

--- a/flowblocks/gazplaceflow.ini
+++ b/flowblocks/gazplaceflow.ini
@@ -10,6 +10,7 @@ source = site.query('/Gaz').filter(F._model == 'gazplace')
 item_key = {{ this._slug }}
 item_label = {{ this._slug }}
 width = 1/2
+default =
 
 [fields.fragment]
 label = Add # Fragment

--- a/flowblocks/maplink.ini
+++ b/flowblocks/maplink.ini
@@ -7,8 +7,10 @@ label = Link Text
 description = This will be shown as "Learn more about ..."
 type = string
 width = 1/3
+default =
 
 [fields.url]
 label = Link Location
 type = string
 width = 2/3
+default = 

--- a/flowblocks/otherweb.ini
+++ b/flowblocks/otherweb.ini
@@ -6,16 +6,20 @@ button_label = Otherweb
 label = Number
 type = integer
 width = 1/4
+default = 0
 
 [fields.link]
 label = Link
 type = string
 width = 3/4
+default =
 
 [fields.text]
 label = Reference
 type = markup
+default =
 
 [fields.more]
 label = More Text
 type = markup
+default = 

--- a/flowblocks/quotation.ini
+++ b/flowblocks/quotation.ini
@@ -5,7 +5,9 @@ button_label = [[quote-right]]
 [fields.quote]
 label = Quote
 type = markup
+default =
 
 [fields.source]
 label = Source
 type = markup
+default = 

--- a/flowblocks/reference.ini
+++ b/flowblocks/reference.ini
@@ -6,7 +6,9 @@ button_label = Reference
 label = Number
 type = integer
 width = 1/4
+default = 0
 
 [fields.reference]
 label = Reference
 type = markup
+default = 

--- a/flowblocks/sidebarlink.ini
+++ b/flowblocks/sidebarlink.ini
@@ -5,7 +5,9 @@ button_label = [[external-link]]
 [fields.url]
 label = URL/Page
 type = string
+default =
 
 [fields.text]
 label = Text
 type = string
+default = 

--- a/flowblocks/translation.ini
+++ b/flowblocks/translation.ini
@@ -6,7 +6,9 @@ button_label = Translation
 label = Number
 type = integer
 width = 1/4
+default = 0
 
 [fields.translation]
 label = Translation
 type = markup
+default = 

--- a/models/biography.ini
+++ b/models/biography.ini
@@ -11,16 +11,19 @@ model = biographyimage
 label = Short Name
 type = string
 width = 1/2
+default =
 
 [fields.fullname]
 label = Full Name
 type = string
 width = 1/2
+default =
 
 [fields.alphabetical]
 label = Alphabetical Index
 description = How this biography should be displayed on the indexes, one line per entry
 type = strings
+default =
 
 [fields.tags]
 label = Categories
@@ -29,6 +32,7 @@ type = checkboxes
 source = site.query('/Categories').include_undiscoverable(True).filter(F.for.contains('biographies'))
 item_key = {{ this._slug }}
 item_label = {{ this.name }}
+default =
 
 [fields.datedescription]
 label =
@@ -39,31 +43,37 @@ description = "Birth Date" and "Death Date" should be in the following format: "
 label = Birth Date
 type = string
 width = 1/4
+default =
 
 [fields.birthyear]
 label = Birth Year
 type = integer
 width = 1/4
+default = 0
 
 [fields.birthplace]
 label = Birth Place
 type = string
 width = 1/2
+default =
 
 [fields.deathdate]
 label = Death Date
 type = string
 width = 1/4
+default =
 
 [fields.deathyear]
 label = Death Year
 type = integer
 width = 1/4
+default = 0
 
 [fields.deathplace]
 label = Death Place
 type = string
 width = 1/2
+default =
 
 [fields.maplocation]
 label = Map Location
@@ -73,12 +83,14 @@ source = site.query('/Map').include_undiscoverable(True)
 item_key = {{ this._slug }}
 item_label = {{ this._slug }}
 width = 1/3
+default =
 
 [fields.nearplace]
 label = Map At Place
 description = If the map location is a general location, this should be the actual birthplace (ie. 'Westminster' or 'Hackney')
 type = string
 width = 1/3
+default =
 
 [fields.country]
 label = Birth Country
@@ -88,56 +100,67 @@ source = site.query('/Countries').include_undiscoverable(True)
 item_key = {{ this._slug }}
 item_label = {{ this._slug }}
 width = 1/3
+default =
 
 [fields.authors]
 label = Authors
 type = markup
 width = 1/2
+default =
 
 [fields.update]
 label = Update
 type = string
 width = 1/2
+default =
 
 [fields.summary]
 label = Summary
 type = markup
+default =
 
 [fields.references]
 label = References
 type = chooser
 flow_block = reference
 key_field = number
+default =
 
 [fields.translations]
 label = Translations
 type = chooser
 flow_block = translation
 key_field = number
+default =
 
 [fields.additional]
 label = Additional Internal Resources
 type = chooser
 flow_block = otherweb
 key_field = number
+default =
 
 [fields.otherweb]
 label = External Resources
 type = chooser
 flow_block = otherweb
 key_field = number
+default =
 
 [fields.honours]
 label = Honours
 type = chooser
 flow_block = otherweb
 key_field = number
+default =
 
 [fields.content]
 label = Biography
 type = markup
+default =
 
 [fields.quotations]
 label = Quotations
 type = flow
 flow_blocks = quotation
+default = 

--- a/models/biographyimage.ini
+++ b/models/biographyimage.ini
@@ -13,12 +13,14 @@ default = no
 label = Description
 description = The caption/description of the image, for PictDisplay. This will be ignored for a Thumbnail image.
 type = markup
+default =
 
 [fields.order]
 label = Display Order
 description = The order the image is displayed in, for PictDisplay. This will be ignored for a Thumbnail.
 type = integer
 width = 1/3
+default = 0
 
 [fields.height]
 label = Display Height
@@ -26,11 +28,13 @@ description = The height the image is displayed at, for PictDisplay. This will b
 type = integer
 width = 1/3
 addon_label = px
+default = 326
 
 [fields.position]
 label = Display Position
 description = The positioning of the image, for PictDisplay. This will be ignored for a Thumbnail image.
 type = select
 choices = L, R, C
-choice_labels = Thumbnail, Left, Right, Centre
+choice_labels = Left, Right, Centre
 width = 1/3
+default = C

--- a/models/biographyindex.ini
+++ b/models/biographyindex.ini
@@ -15,3 +15,4 @@ label = Non-Biography Links
 description = Allows the adding of non-biographies to the biography indexes.
 type = flow
 flow_blocks = biographylink
+default = 

--- a/models/bmc.ini
+++ b/models/bmc.ini
@@ -7,54 +7,59 @@ hidden = yes
 label = Year
 type = integer
 width = 1/4
+default = 0
 
 [fields.date]
 label = Date
 type = string
 width = 3/4
-
+default =
 
 [fields.size]
 label = Enrolment Size
 type = integer
 width = 1/4
+default = 0
 
 [fields.place]
 label = Place
 type = string
 width = 3/4
-
+default =
 
 [fields.organisers]
 label = Organisers
 type = string
 width = 1/2
+default =
 
 [fields.chair]
 label = Chair
 type = string
 width = 1/2
-
+default =
 
 [fields.secretary]
 label = Secretary
 type = string
 width = 1/2
+default =
 
 [fields.partner]
 label = Partner
 type = string
 width = 1/2
-
+default =
 
 [fields.indexlinks]
 label = Index Links
 description = Which links to minutes of meetings should appear on the BMC index page.
 type = flow
 flow_blocks = bmcindexlink
-
+default =
 
 [fields.speakertypes]
 label = Speakers
 type = flow
 flow_blocks = bmcspeakertype
+default = 

--- a/models/bmcindex.ini
+++ b/models/bmcindex.ini
@@ -6,3 +6,4 @@ hidden = yes
 [fields.description]
 label = Description
 type = markup
+default = 

--- a/models/category.ini
+++ b/models/category.ini
@@ -7,6 +7,7 @@ hidden = yes
 label = Name
 description = Human readable name for the category.
 type = string
+default =
 
 [fields.for]
 label = For
@@ -14,8 +15,10 @@ description = What types of pages this category can be applied to.
 type = checkboxes
 choices = biographies, histtopics, honours, societies
 choice_labels = Biographies, History Topics, Honours, Societies
+default =
 
 [fields.description]
 label = Description
 label = An optional description for the category.
 type = markup
+default = 

--- a/models/chronologyyear.ini
+++ b/models/chronologyyear.ini
@@ -6,8 +6,10 @@ hidden = yes
 [fields.year]
 label = Year
 type = integer
+default = 0
 
 [fields.events]
 label = Events
 type = flow
 flow_blocks = chronology-event
+default = 

--- a/models/country.ini
+++ b/models/country.ini
@@ -6,3 +6,4 @@ hidden = yes
 [fields.name]
 label = Name
 type = string
+default = 

--- a/models/countryindex.ini
+++ b/models/countryindex.ini
@@ -9,7 +9,9 @@ model = country
 [fields.title]
 label = Title
 type = string
+default =
 
 [fields.content]
 label = Description
 type = markup
+default = 

--- a/models/curve.ini
+++ b/models/curve.ini
@@ -10,17 +10,21 @@ model = curveimage
 [fields.name]
 label = Name
 type = string
+default =
 
 [fields.equations]
 label = Equations
 type = flow
 flow_blocks = curveequation
+default =
 
 [fields.appletoptions]
 label = Applet Options
 description = The options (as a JavaScript object) to be passed to the interactive curve applet.
 type = text
+default =
 
 [fields.content]
 label = Content
 type = markup
+default = 

--- a/models/curveimage.ini
+++ b/models/curveimage.ini
@@ -6,6 +6,7 @@ hidden = yes
 label = Curve Name
 description = Used as the text of the link to this curve
 type = string
+default =
 
 [fields.main]
 label = Main Image

--- a/models/curveindex.ini
+++ b/models/curveindex.ini
@@ -9,7 +9,9 @@ model = curve
 [fields.title]
 label = Title
 type = string
+default =
 
 [fields.content]
 label = Description
 type = markup
+default = 

--- a/models/education.ini
+++ b/models/education.ini
@@ -9,13 +9,16 @@ model = page
 label = Title
 type = string
 width = 2/3
+default =
 
 [fields.number]
 label = Sort Order
 description = This is used to order the education pages.
 type = integer
 width = 1/3
+default = 0
 
 [fields.content]
 label = Content
 type = markup
+default = 

--- a/models/educationindex.ini
+++ b/models/educationindex.ini
@@ -10,7 +10,9 @@ order_by = number
 [fields.title]
 label = Title
 type = string
+default =
 
 [fields.content]
 label = Description
 type = markup
+default = 

--- a/models/extra.ini
+++ b/models/extra.ini
@@ -7,21 +7,26 @@ hidden = yes
 label = Title
 type = string
 width = 1/2
+default =
 
 [fields.update]
 label = Update
 type = string
 width = 1/2
+default =
 
 [fields.headline]
 label = Headline
 type = markup
+default =
 
 [fields.references]
 label = References
 type = flow
 flow_blocks = reference
+default =
 
 [fields.content]
 label = Content
 type = markup
+default = 

--- a/models/extrasindex.ini
+++ b/models/extrasindex.ini
@@ -9,7 +9,9 @@ model = extra
 [fields.title]
 label = Title
 type = string
+default =
 
 [fields.content]
 label = Description
 type = markup
+default = 

--- a/models/frse.ini
+++ b/models/frse.ini
@@ -6,33 +6,40 @@ hidden = yes
 [fields.name]
 label = Name
 type = markup
+default =
 
 [fields.birth]
 label = Birth Date
 type = string
 width = 1/3
+default =
 
 [fields.death]
 label = Death Date
 type = string
 width = 1/3
+default =
 
 [fields.birthplace]
 label = Birth Place
 type = string
 width = 1/3
+default =
 
 [fields.elected]
 label = Elected Date
 type = date
 width = 1/2
+default = 01/01/1900
 
 [fields.profession]
 label = Profession
 type = string
 width = 1/2
+default =
 
 [fields.fellowship]
 label = Fellowship Type
 type = string
 width = 1/2
+default = 

--- a/models/frseindex.ini
+++ b/models/frseindex.ini
@@ -10,6 +10,7 @@ model = frse
 label = Title
 type = string
 width = 2/3
+default =
 
 [fields.order_by]
 label = Index Order
@@ -18,7 +19,9 @@ type = select
 choices = _slug, elected
 choice_labels = Filename, Election Date
 width = 1/3
+default = _slug
 
 [fields.content]
 label = Description
 type = markup
+default =

--- a/models/gazindex.ini
+++ b/models/gazindex.ini
@@ -6,7 +6,9 @@ hidden = yes
 [fields.title]
 label = Title
 type = string
+default =
 
 [fields.content]
 label = Description
 type = markup
+default = 

--- a/models/gazperson.ini
+++ b/models/gazperson.ini
@@ -6,8 +6,10 @@ hidden = yes
 [fields.name]
 label = Person Name
 type = string
+default =
 
 [fields.places]
 label = Places
 type = flow
 flow_blocks = gazplaceflow
+default = 

--- a/models/gazplace.ini
+++ b/models/gazplace.ini
@@ -7,23 +7,28 @@ hidden = yes
 label = Place Name
 type = string
 width = 1/2
+default =
 
 [fields.longitude]
 label = Longitude
 type = float
 width = 1/4
+default = 0.0
 
 [fields.latitude]
 label = Latitude
 type = float
 width = 1/4
+default = 0.0
 
 [fields.references]
 label = References
 type = chooser
 flow_block = reference
 key_field = number
+default =
 
 [fields.content]
 label = Content
 type = markup
+default = 

--- a/models/glossary.ini
+++ b/models/glossary.ini
@@ -6,7 +6,9 @@ hidden = yes
 [fields.term]
 label = Term
 type = string
+default =
 
 [fields.content]
 label = Content
 type = markup
+default = 

--- a/models/historytopic.ini
+++ b/models/historytopic.ini
@@ -6,25 +6,30 @@ hidden = yes
 [fields.shortname]
 label = Short Name
 type = string
+default =
 
 [fields.fullname]
 label = Full Name
 type = markup
+default =
 
 [fields.alphabetical]
 label = Alphabetical Index
 description = How this history topic should be displayed on the indexes, one line per entry
 type = strings
+default =
 
 [fields.authors]
 label = Authors
 type = markup
 width = 1/2
+default =
 
 [fields.update]
 label = Update
 type = string
 width = 1/2
+default =
 
 [fields.tags]
 label = Categories
@@ -33,27 +38,34 @@ type = checkboxes
 source = site.query('/Categories').include_undiscoverable(True).filter(F.for.contains('histtopics'))
 item_key = {{ this._slug }}
 item_label = {{ this.name }}
+default =
+
 [fields.references]
 label = References
 type = flow
 flow_blocks = reference
+default =
 
 [fields.additional]
 label = Additional Internal Resources
 type = flow
 flow_blocks = otherweb
+default =
 
 [fields.otherweb]
 label = External Resources
 type = flow
 flow_blocks = otherweb
+default =
 
 [fields.translations]
 label = Translations
 type = chooser
 flow_block = translation
 key_field = number
+default =
 
 [fields.content]
 label = Content
 type = markup
+default = 

--- a/models/historytopicindex.ini
+++ b/models/historytopicindex.ini
@@ -9,7 +9,9 @@ model = historytopic
 [fields.title]
 label = Title
 type = string
+default =
 
 [fields.content]
 label = Description
 type = markup
+default = 

--- a/models/honour.ini
+++ b/models/honour.ini
@@ -6,15 +6,18 @@ hidden = yes
 [fields.title]
 label = Title
 type = string
+default =
 
 [fields.headline]
 label = Headline
 type = markup
+default =
 
 [fields.alphabetical]
 label = Alphabetical Index
 description = How this honour should be displayed on the indexes, one line per entry
 type = strings
+default =
 
 [fields.tags]
 label = Categories
@@ -23,7 +26,9 @@ type = checkboxes
 source = site.query('/Categories').include_undiscoverable(True).filter(F.for.contains('honours'))
 item_key = {{ this._slug }}
 item_label = {{ this.name }}
+default =
 
 [fields.content]
 label = Content
 type = markup
+default = 

--- a/models/honourindex.ini
+++ b/models/honourindex.ini
@@ -9,7 +9,9 @@ model = honour
 [fields.title]
 label = Title
 type = string
+default =
 
 [fields.content]
 label = Description
 type = markup
+default = 

--- a/models/icmindex.ini
+++ b/models/icmindex.ini
@@ -9,7 +9,9 @@ model = page
 [fields.title]
 label = Title
 type = string
+default =
 
 [fields.content]
 label = Description
 type = markup
+default = 

--- a/models/indexes.ini
+++ b/models/indexes.ini
@@ -6,7 +6,9 @@ hidden = yes
 [fields.title]
 label = Title
 type = string
+default =
 
 [fields.indexof]
 label = Index Of
 type = string
+default = 

--- a/models/obituary.ini
+++ b/models/obituary.ini
@@ -6,15 +6,19 @@ hidden = yes
 [fields.name]
 label = Title
 type = string
+default =
 
 [fields.wherefrom]
 label = Where From
 type = string
+default =
 
 [fields.summary]
 label = Summary
 type = markup
+default =
 
 [fields.content]
 label = Content
 type = markup
+default = 

--- a/models/obituaryindex.ini
+++ b/models/obituaryindex.ini
@@ -9,7 +9,9 @@ model = obituary
 [fields.title]
 label = Title
 type = string
+default =
 
 [fields.content]
 label = Description
 type = markup
+default = 

--- a/models/page.ini
+++ b/models/page.ini
@@ -6,17 +6,21 @@ label = {{ this._slug }}
 label = Title
 type = string
 width = 1/2
+default =
 
 [fields.authors]
 label = Author(s)
 type = markup
 width = 1/2
+default =
 
 [fields.content]
 label = Content
 type = markup
+default =
 
 [fields.sidebar]
 label = Sidebar
 type = flow
 flow_blocks = sidebarlink
+default = 

--- a/models/parismap.ini
+++ b/models/parismap.ini
@@ -7,13 +7,16 @@ hidden = yes
 label = Street Name
 type = string
 width = 1/2
+default =
 
 [fields.longitude]
 label = Longitude
 type = float
 width = 1/4
+default = 0.0
 
 [fields.latitude]
 label = Latitude
 type = float
 width = 1/4
+default = 0.0

--- a/models/parismapindex.ini
+++ b/models/parismapindex.ini
@@ -6,7 +6,9 @@ hidden = yes
 [fields.title]
 label = Title
 type = string
+default =
 
 [fields.content]
 label = Description
 type = markup
+default = 

--- a/models/place.ini
+++ b/models/place.ini
@@ -7,6 +7,7 @@ hidden = yes
 label = Name
 type = string
 width = 1/2
+default =
 
 [fields.country]
 label = Country
@@ -16,11 +17,13 @@ source = site.query('/Countries').include_undiscoverable(True)
 item_key = {{ this._slug }}
 item_label = {{ this._slug }}
 width = 1/2
+default =
 
 [fields.links]
 label = "Learn More" Links
 type = flow
 flow_blocks = maplink
+default =
 
 [fields.gaz]
 label = Gazetteer Entry
@@ -30,13 +33,16 @@ source = site.query('/Gaz').filter(F._model == 'gazplace')
 item_key = {{ this._slug }}
 item_label = {{ this._slug }}
 width = 1/2
+default =
 
 [fields.longitude]
 label = Longitude
 type = float
 width = 1/4
+default = 0.0
 
 [fields.latitude]
 label = Latitude
 type = float
 width = 1/4
+default = 0.0

--- a/models/project.ini
+++ b/models/project.ini
@@ -11,14 +11,17 @@ order_by = chapter
 label = Title
 type = string
 width = 2/3
+default =
 
 [fields.author]
 label = Author
 type = string
 width = 1/3
+default =
 
 [fields.references]
 label = References
 type = flow
 flow_blocks = reference
 key_field = number
+default = 

--- a/models/projectpage.ini
+++ b/models/projectpage.ini
@@ -7,13 +7,16 @@ hidden = yes
 label = Title
 type = string
 width = 3/4
+default =
 
 [fields.chapter]
 label = Chapter Number
 description = This is used to order the project chapters.
 type = integer
 width = 1/3
+default = 0
 
 [fields.content]
 label = Content
 type = markup
+default = 

--- a/models/projectsindex.ini
+++ b/models/projectsindex.ini
@@ -9,7 +9,9 @@ model = project
 [fields.title]
 label = Title
 type = string
+default =
 
 [fields.content]
 label = Description
 type = markup
+default = 

--- a/models/society.ini
+++ b/models/society.ini
@@ -6,29 +6,35 @@ hidden = yes
 [fields.name]
 label = Title
 type = string
+default =
 
 [fields.headline]
 label = Headline
 type = markup
+default =
 
 [fields.alphabetical]
 label = Alphabetical Index
 description = How this society topic should be displayed on the indexes, one line per entry
 type = strings
+default =
 
 [fields.foundation]
 label = Foundation Date
 type = string
 width = 1/2
+default =
 
 [fields.update]
 label = Update
 type = string
 width = 1/2
+default =
 
 [fields.website]
 label = External Website
 type = string
+default =
 
 [fields.tags]
 label = Categories
@@ -37,18 +43,22 @@ type = checkboxes
 source = site.query('/Categories').include_undiscoverable(True).filter(F.for.contains('societies'))
 item_key = {{ this._slug }}
 item_label = {{ this.name }}
+default =
 
 [fields.references]
 label = References
 type = flow
 flow_blocks = reference
+default =
 
 [fields.additional]
 label = Additional Internal Resources
 type = chooser
 flow_block = otherweb
 key_field = number
+default =
 
 [fields.content]
 label = Content
 type = markup
+default = 

--- a/models/societyindex.ini
+++ b/models/societyindex.ini
@@ -9,7 +9,9 @@ model = society
 [fields.title]
 label = Title
 type = string
+default =
 
 [fields.content]
 label = Description
 type = markup
+default = 


### PR DESCRIPTION
In the plugins, when getting a value of a field, if no default value is specified, then `Undefined` is returned, which messes things up. I've written them to be expecting empty values.

This gives all fields in all models and flowblocks sensible default values (nearly always an empty string, except for numeric and date types).