### PR TITLE
Fix url escaping

### DIFF
--- a/packages/mathshistory-jinja/lektor_mathshistory_jinja.py
+++ b/packages/mathshistory-jinja/lektor_mathshistory_jinja.py
@@ -70,6 +70,9 @@ class MathshistoryJinjaPlugin(Plugin):
                 return 'were'
             return tense(year)
 
+        def actual_safe(text):
+            return text.__html__().unescape()
+
         self.env.jinja_env.filters['refs_format'] = refs_format
         self.env.jinja_env.filters['basename'] = basename
         self.env.jinja_env.filters['without_ext'] = without_ext
@@ -79,3 +82,4 @@ class MathshistoryJinjaPlugin(Plugin):
         self.env.jinja_env.filters['tense'] = tense
         self.env.jinja_env.filters['tense_plural'] = tense_plural
         self.env.jinja_env.filters['num2words'] = num2words
+        self.env.jinja_env.filters['actual_safe'] = actual_safe

--- a/templates/biography.html
+++ b/templates/biography.html
@@ -152,7 +152,7 @@
   <div class="col-md-12">
     <ol name="xrefs">
       {% for xref in this.xrefs %}
-      <li><a href="{{ xref.record|url }}">{{ xref.title|safe }}</a></li>
+      <li><a href="{{ xref.record|url }}">{{ xref.title|actual_safe|safe }}</a></li>
       {% endfor %}
     </ol>
   </div>

--- a/templates/blocks/otherweb.html
+++ b/templates/blocks/otherweb.html
@@ -1,1 +1,1 @@
-<li><a href="{{ this.link|any_url }}">{{ this.text|safe }}</a></li>
+<li><a href="{{ this.link|any_url }}">{{ this.text|actual_safe|safe }}</a></li>

--- a/templates/blocks/reference.html
+++ b/templates/blocks/reference.html
@@ -1,1 +1,1 @@
-<li id="reference-{{ this.number }}">{{ this.reference|safe }}</li>
+<li id="reference-{{ this.number }}">{{ this.reference|actual_safe|safe }}</li>

--- a/templates/macros/additional.html
+++ b/templates/macros/additional.html
@@ -25,7 +25,7 @@
       <ol name="otherweb">
         {% for otherweb in otherwebs.blocks %}
         {# we're not just using {{ otherweb }} because we want to make it open in new tab #}
-        <li><a href="{{ otherweb.link|any_url }}" target="_blank">{{ otherweb.text|safe }}</a></li>
+        <li><a href="{{ otherweb.link|any_url }}" target="_blank">{{ otherweb.text|actual_safe|safe }}</a></li>
         {% endfor %}
       </ol>
     </div>


### PR DESCRIPTION
Fixes #232 by adding new `actual_safe` filter, which actually returns the markup as it was supposed to be, including with the raw URLs inside the HTML.