### PR TITLE
Sort poster image query

### DIFF
--- a/templates/plugins/biographylivedposter.html
+++ b/templates/plugins/biographylivedposter.html
@@ -32,7 +32,7 @@
   <body class="poster">
     <div class="poster-main">
       <p>
-        {% set bigimages = this.parent.attachments.images.filter(F._model == 'biographyimage').filter(F.main == False) %}
+        {% set bigimages = this.parent.attachments.images.filter(F._model == 'biographyimage').filter(F.main == False).order_by('order') %}
         <img src="{{ bigimages.first()|url }}" />
       </p>
 

--- a/templates/plugins/biographyposter.html
+++ b/templates/plugins/biographyposter.html
@@ -32,7 +32,7 @@
   <body class="poster">
     <div class="poster-main">
       <p>
-        {% set bigimages = this.parent.attachments.images.filter(F._model == 'biographyimage').filter(F.main == False) %}
+        {% set bigimages = this.parent.attachments.images.filter(F._model == 'biographyimage').filter(F.main == False).order_by('order') %}
         <img src="{{ bigimages.first()|url }}" />
       </p>
 


### PR DESCRIPTION
Before we choose the first image from the query as the image to use on the poster, sort it by `order`. This ensures we're picking the first image, rather than (what seems to be) the last one.