### PR TITLE
Remove incorrect application of actual_safe filter on string

### DIFF
--- a/templates/biography.html
+++ b/templates/biography.html
@@ -152,7 +152,7 @@
   <div class="col-md-12">
     <ol name="xrefs">
       {% for xref in this.xrefs %}
-      <li><a href="{{ xref.record|url }}">{{ xref.title|actual_safe|safe }}</a></li>
+      <li><a href="{{ xref.record|url }}">{{ xref.title|safe }}</a></li>
       {% endfor %}
     </ol>
   </div>


### PR DESCRIPTION
The `actual_safe` filter was used on the `xrefs.title` value, which is a string, not a instance of markup, which made the build crash.