### PR TITLE
Use margin rather than padding on pictdisplay images

### DIFF
--- a/assets/static/css/site.css
+++ b/assets/static/css/site.css
@@ -100,7 +100,7 @@ img {
   text-align: center;
 }
 .pictdisplay.row img {
-  padding: 10px;
+  margin: 10px;
 }
 
 #_Loader-status {


### PR DESCRIPTION
Change the padding on images in the pictdisplay pages to margin instead, to ensure that the images are being set to the specified height in Lektor.