### PR TITLE
Use specified image height for pictdisplay

### DIFF
--- a/templates/plugins/pictdisplay.html
+++ b/templates/plugins/pictdisplay.html
@@ -48,7 +48,7 @@
   <div class="col-md-6">
   {% endif %}
 
-  <img src="{{ image|url }}"{% if image.height %} style="height: {{ image.height }}px"{% endif %} />
+  <img src="{{ image|url }}"{% if image['height'] %} style="height: {{ image['height'] }}px"{% endif %} />
   {% if image.description %}
   <p>{{ image.description }}</p>
   {% endif %}


### PR DESCRIPTION
Rather than using the actual image height from the image metadata, use the image height specified in the Lektor file instead.