### PR TITLE
Use displayname for mathematicians on map

### DIFF
--- a/packages/mathshistory-map/setup.py
+++ b/packages/mathshistory-map/setup.py
@@ -25,7 +25,7 @@ setup(
     packages=find_packages(),
     py_modules=['lektor_mathshistory_map'],
     url='https://github.com/mathshistory/mathshistory-map',
-    version='1.2.1',
+    version='1.2.2',
     classifiers=[
         'Framework :: Lektor',
         'Environment :: Plugins',


### PR DESCRIPTION
Rather than using shortname for mathematicians on a map location (which is their firstname then lastname), use the displayname (ie. alphabetical index) so it displays lastname then firstname, in line with the rest of the site