### PR TITLE
Accessibility

### DIFF
--- a/assets/static/css/content.css
+++ b/assets/static/css/content.css
@@ -52,7 +52,7 @@ blockquote:before {
 
 /* [gl]...[/gl] */
 .gllink {
-  color: green;
+  color: #008000;
 }
 
 /* [ac]...[/ac] */
@@ -72,7 +72,7 @@ blockquote:before {
 
 /* [t]...[/t] */
 .translation {
-  color: red !important;
+  color: #EB0000 !important;
   cursor: pointer;
 }
 
@@ -95,17 +95,17 @@ table {
 }
 
 .math-error {
-  color: red;
+  color: #EB0000;
 }
 
 .red-text {
-  color: red;
+  color: #EB0000;
 }
 .blue-text {
   color: blue;
 }
 .green-text {
-  color: green;
+  color: #008000;
 }
 .brown-text {
   color: brown;

--- a/assets/static/css/site.css
+++ b/assets/static/css/site.css
@@ -177,3 +177,8 @@ img {
 .skip-link:focus {
   transform: translateY(0%);
 }
+
+main a, footer a {
+  text-decoration: underline;
+  text-decoration-color: lightgrey;
+}

--- a/assets/static/css/site.css
+++ b/assets/static/css/site.css
@@ -162,3 +162,17 @@ img {
 .jump-label {
   text-transform: capitalize;
 }
+
+/* for the "jump to content" link on all pages */
+.skip-link {
+  background-color: #ffffff;
+  border: 1px solid #e5e5e5;
+  font-weight: 700;
+  padding: 4px;
+  position: absolute;
+  transform: translateY(-200%);
+}
+
+.skip-link:focus {
+  transform: translateY(0%);
+}

--- a/assets/static/css/site.css
+++ b/assets/static/css/site.css
@@ -25,6 +25,7 @@ h1, h2, h3, h4, h5, h6, ol, ul {
   padding: 0;
   background-color: initial;
   border-top: 1px solid #e5e5e5;
+  color: #000000;
 }
 .site-footer .row {
   margin-left: 0px;

--- a/assets/static/css/site.css
+++ b/assets/static/css/site.css
@@ -182,3 +182,25 @@ main a, footer a {
   text-decoration: underline;
   text-decoration-color: lightgrey;
 }
+
+.blockquote-quotations-page {
+  background: initial;
+  border-left: initial;
+  margin-bottom: 0.7em;
+  padding: initial;
+  quotes: initial;
+  font-style: initial;
+  text-align: initial;
+}
+.blockquote-body {
+  background: #f9f9f9;
+  border-left: 10px solid #ccc;
+  padding: 0.5em 10px;
+  quotes: "\201C""\201D""\2018""\2019";
+  font-style: italic;
+  text-align: justify;
+}
+.blockquote-footer {
+  color: #000000;
+  font-size: initial;
+}

--- a/models/biographyimage.ini
+++ b/models/biographyimage.ini
@@ -10,10 +10,16 @@ checkbox_label = If this image should be displayed as the thumbnail, check this.
 default = no
 
 [fields.description]
-label = Description
+label = Caption
 description = The caption/description of the image, for PictDisplay. This will be ignored for a Thumbnail image.
 type = markup
 default =
+
+[fields.alttext]
+label = Alt Text
+description = The alternative text ("alt tag") of the image, for PictDisplay. This will be ignored for a Thumbnail image.
+type = text
+default = 
 
 [fields.order]
 label = Display Order

--- a/models/diagram.ini
+++ b/models/diagram.ini
@@ -1,0 +1,9 @@
+[model]
+name = Diagram
+hidden = yes
+
+[fields.alttext]
+label = Alt Text
+description = The alternative text ("alt tag") of the diagram.
+type = text
+default = 

--- a/models/diagrams.ini
+++ b/models/diagrams.ini
@@ -1,0 +1,17 @@
+[model]
+name = Attachment Store
+label = {{ this._slug }}
+hidden = yes
+
+[attachments]
+enabled = yes
+model = diagram
+
+[fields.heading]
+type = heading
+heading = This is an attachment store.
+
+[fields.description]
+type = info
+label =
+description = An attachment store does not have any content itself, rather it is a place where extra material can be uploaded (such as images or PDFs). Use the "Add Attachment" button and the list of attachments to the right to manage these attachments.

--- a/packages/mathshistory-renderer/README.md
+++ b/packages/mathshistory-renderer/README.md
@@ -3,5 +3,3 @@
 Renders the markup used for the maths history site into HTML.
 
 This was originally adapted from the `htmlformat` function of the `html format.rev` stack.
-
-Line breaks and paragraphs still need to be fixed.

--- a/packages/mathshistory-renderer/lektor_mathshistory_renderer.py
+++ b/packages/mathshistory-renderer/lektor_mathshistory_renderer.py
@@ -341,10 +341,26 @@ def drender(match, record):
         name = '%s.gif' % name
     href = '/Diagrams/%s' % name
 
-    if params != '':
-        return '<img class="diagram" src="%s" %s />' % (href, params)
+    # get the alt text
+    try:
+        pad = get_ctx().pad
+        diagram = pad.get(href)
+        alttext = diagram['alttext']
+        alttext = html.escape(alttext, quote=True)
+    except:
+        print('Error getting alt text for diagram "%s"' % href)
+        traceback.print_exc()
+        alttext = False
+
+    if alttext:
+        alttag = ' alt="%s"' % alttext
     else:
-        return '<img class="diagram" src="%s" />' % href
+        alttag = ''
+
+    if params != '':
+        return '<img class="diagram"%s src="%s" %s />' % (alttag, href, params)
+    else:
+        return '<img class="diagram"%s src="%s" />' % (alttag, href)
 
 
 def katexprerender(match, storage):

--- a/packages/mathshistory-renderer/lektor_mathshistory_renderer.py
+++ b/packages/mathshistory-renderer/lektor_mathshistory_renderer.py
@@ -404,6 +404,7 @@ def correct_link(link, record):
 # this might be quite slow. but John likes non-italic numbers/brackets, so it has to stay for now
 NON_ITALIC_PATTERN = re.compile(r'([\d\[\]\(\)]+)')
 NON_ITALIC_DONT_MATCH_TAG = ('pre','code')
+TAG_REPLACEMENTS = [('b', 'strong'), ('i', 'em')]
 def fix_italics(x, record):
     try:
         s = BeautifulSoup(x, 'html5lib')
@@ -447,6 +448,11 @@ def fix_italics(x, record):
 
                 # non-urls get standard conversion
                 link['href'] = correct_link(link['href'], record)
+        
+        # replace <b> with <strong> and <i> with <em>
+        for tag, new_tag in TAG_REPLACEMENTS:
+            for node in s.find_all(tag, {}):
+                node.name = new_tag
 
         # render it back to a string
         out = ''.join((str(child) for child in s.body.children))

--- a/packages/mathshistory-renderer/setup.py
+++ b/packages/mathshistory-renderer/setup.py
@@ -26,7 +26,7 @@ setup(
     install_requires=['beautifulsoup4','html5lib','regex'],
     py_modules=['lektor_mathshistory_renderer'],
     url='https://github.com/mathshistory/mathshistory-renderer',
-    version='0.4.13',
+    version='0.4.14',
     classifiers=[
         'Framework :: Lektor',
         'Environment :: Plugins',

--- a/packages/mathshistory-renderer/setup.py
+++ b/packages/mathshistory-renderer/setup.py
@@ -26,7 +26,7 @@ setup(
     install_requires=['beautifulsoup4','html5lib','regex'],
     py_modules=['lektor_mathshistory_renderer'],
     url='https://github.com/mathshistory/mathshistory-renderer',
-    version='0.4.12',
+    version='0.4.13',
     classifiers=[
         'Framework :: Lektor',
         'Environment :: Plugins',

--- a/templates/biography.html
+++ b/templates/biography.html
@@ -79,7 +79,7 @@
     {% if numbigimages > 0 %}
     <a href="{{ '%s/@pictdisplay'|format(this.path)|url }}" target="_blank">
     {% endif %}
-    <img class="biography-thumbnail" src="{{ thumbnail|url }}" />
+    <img class="biography-thumbnail" src="{{ thumbnail|url }}" alt="Thumbnail of {{ this.shortname|e }}" />
     {% if numbigimages > 0 %}
     <br/>
     View {{ numbigimages|num2words }} larger picture{% if numbigimages > 1 %}s{% endif %}</a>

--- a/templates/biography.html
+++ b/templates/biography.html
@@ -137,7 +137,6 @@
       {% endfor %}
     </ol>
   </div>
-  </div>
 </div>
 {% endif %}
 
@@ -155,7 +154,6 @@
       <li><a href="{{ xref.record|url }}">{{ xref.title|safe }}</a></li>
       {% endfor %}
     </ol>
-  </div>
   </div>
 </div>
 {% endif %}

--- a/templates/biographyindex.html
+++ b/templates/biographyindex.html
@@ -31,7 +31,6 @@
       <li><a href="{{ '/@otherindexes/pictures'|url }}">Pictures</a></li>
       <li><a href="{{ '/Miscellaneous/recent_changes'|url }}">Recent Changes</a></li>
     </ul>
-    </div>
   </div>
 </div>
 

--- a/templates/biographyindex.html
+++ b/templates/biographyindex.html
@@ -22,7 +22,7 @@
 
 <div class="row px-5">
   <div class="col">
-    <div id="alphabetical-index-jumpbox" class="mb-3">
+    <div class="mb-3">
       <h1>Other Indexes</h1>
     </div>
     <ul>
@@ -38,7 +38,7 @@
 {% for column in get_categories_by_type(site, 'biographies')|slice(2) %}
 {% if loop.first %}
 <div class="row px-5 mt-3">
-  <div id="alphabetical-index-jumpbox" class="col-md-12">
+  <div class="col-md-12">
     <h1>Categories</h1>
   </div>
 {% endif %}

--- a/templates/blocks/quotation.html
+++ b/templates/blocks/quotation.html
@@ -1,5 +1,7 @@
-<blockquote>
-  {{ this.quote }}
+<blockquote class="blockquote-quotations-page">
+  <div class="blockquote-body">
+    {{ this.quote }}
+  </div>
   {% if this.source %}
   <footer class="blockquote-footer">{{ this.source }}</footer>
   {% endif %}

--- a/templates/curve.html
+++ b/templates/curve.html
@@ -41,7 +41,7 @@
     {% if image %}
       <img src="{{ image|url }}" alt="{{ image.description|striptags|e }}" />
     {% else %}
-    <i>Error displaying curve</i>
+    <em>Error displaying curve</em>
     {% endif %}
   </div>
 

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -97,7 +97,7 @@
           <a href="{{ '/Miscellaneous/copyright/'|url }}">Copyright information</a>
         </div>
         <div class="links-footer col-md-6">
-          <a href="http://www.st-andrews.ac.uk/maths/" target="_blank">School of Mathematics and Statistics</a>
+          <a href="https://www.st-andrews.ac.uk/mathematics-statistics/" target="_blank">School of Mathematics and Statistics</a>
           <br/>
           <a href="http://www.st-andrews.ac.uk/" target="_blank">University of St Andrews, Scotland</a>
         </div>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -57,7 +57,7 @@
       <div class="row flex-nowrap justify-content-between align-items-center">
         <div class="col pt-1">
           <a class="site-header-name" href="{{ '/'|url }}">
-            <h1 class="site-header-name"><img height="48" src="{{ '/static/img/logo.png'|url }}" />&nbsp;MacTutor</h1>
+            <h1 class="site-header-name"><img height="48" src="{{ '/static/img/logo.png'|url }}" alt="MacTutor logo" />&nbsp;MacTutor</h1>
           </a>
         </div>
       </div>
@@ -102,7 +102,7 @@
           <a href="http://www.st-andrews.ac.uk/" target="_blank">University of St Andrews, Scotland</a>
         </div>
         <div class="col-md-2">
-          <img src="{{ '/static/img/st-andrews-logo.png'|asseturl }}" alt="University of St Andrews logo">
+          <img src="{{ '/static/img/st-andrews-logo.png'|asseturl }}" alt="University of St. Andrews logo">
         </div>
       </div>
       <hr/>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -44,13 +44,16 @@
 </head>
 
 <body>
-  <main role="main" class="container">
+  <div class="container">
 
     {#  tell funnelback not to index the header #}
     <!--noindex-->
 
     <!-- HEADER -->
     <header class="site-header py-3">
+      <!-- skip link for accessibility -->
+      <a class="skip-link" href="#main">Skip to content</a>
+
       <div class="row flex-nowrap justify-content-between align-items-center">
         <div class="col pt-1">
           <a class="site-header-name" href="{{ '/'|url }}">
@@ -80,7 +83,9 @@
 
     <!--endnoindex-->
 
-    {% block body %}{% endblock %}
+    <main id="main">
+      {% block body %}{% endblock %}
+    </main>
 
     {#  tell funnelback not to index the footer #}
     <!--noindex-->
@@ -110,7 +115,7 @@
 
     <!--endnoindex-->
 
-  </main>
+  </div>
 
   {% block scripts %}
   <script src="{{ '/static/js/popper.min.js'|asseturl }}"></script>

--- a/templates/plugins/biographylivedposter.html
+++ b/templates/plugins/biographylivedposter.html
@@ -50,7 +50,7 @@
 
     <div class="poster-moreinfo">
       <p>
-        <i>Find out more at</i>: {{ this.parent|canonical_url }}
+        <em>Find out more at</em>: {{ this.parent|canonical_url }}
       </p>
     </div>
 

--- a/templates/plugins/biographylivedposter.html
+++ b/templates/plugins/biographylivedposter.html
@@ -33,7 +33,7 @@
     <div class="poster-main">
       <p>
         {% set bigimages = this.parent.attachments.images.filter(F._model == 'biographyimage').filter(F.main == False).order_by('order') %}
-        <img src="{{ bigimages.first()|url }}" />
+        <img src="{{ bigimages.first()|url }}" alt="Image of {{ this.parent.shortname|e }}" />
       </p>
 
       <h1>{{ this.parent.shortname }}</h1>

--- a/templates/plugins/biographypopup.html
+++ b/templates/plugins/biographypopup.html
@@ -4,7 +4,7 @@
     {% set thumbnail = this.attachments.images.filter(F._model == 'biographyimage').filter(F.main == True).first() %}
     {% if thumbnail %}
     <div class="float-right">
-      <img class="biography-thumbnail" src="{{ thumbnail|url }}" />
+      <img class="biography-thumbnail" src="{{ thumbnail|url }}" alt="Thumbnail of {{ this.shortname|e }}" />
     </div>
     {% endif %}
     <div>

--- a/templates/plugins/biographyposter.html
+++ b/templates/plugins/biographyposter.html
@@ -47,7 +47,7 @@
 
     <div class="poster-moreinfo">
       <p>
-        <i>Find out more at</i>: {{ this.parent|canonical_url }}
+        <em>Find out more at</em>: {{ this.parent|canonical_url }}
       </p>
     </div>
 

--- a/templates/plugins/biographyposter.html
+++ b/templates/plugins/biographyposter.html
@@ -33,7 +33,7 @@
     <div class="poster-main">
       <p>
         {% set bigimages = this.parent.attachments.images.filter(F._model == 'biographyimage').filter(F.main == False).order_by('order') %}
-        <img src="{{ bigimages.first()|url }}" />
+        <img src="{{ bigimages.first()|url }}" alt="Image of {{ this.parent.shortname|e }}" />
       </p>
 
       <h1>{{ this.parent.shortname }}</h1>

--- a/templates/plugins/curvesapplet.html
+++ b/templates/plugins/curvesapplet.html
@@ -46,7 +46,7 @@
 <div class="row curve-container">
   <div class="col-md-8">
     <noscript>
-      <i>JavaScript is required in order to run the interactive curves.</i>
+      <em>JavaScript is required in order to run the interactive curves.</em>
     </noscript>
     <div id="sysoutdiv"></div>
     <!-- inject the applet -->
@@ -66,9 +66,9 @@
 
 <div class="row">
   <div class="col-md-12">
-    <p>Click on the <b>Curve</b> menu to choose one of the associated curves. Then click on the diagram to choose a point for the involutes, pedal curve, etc. You can then move the point around and watch the associated curve change.</p>
-    <p>For the <b>inverse</b> (wrt a circle) click the mouse and drag to choose a centre and radius. You can then drag the centre of the circle<p>
-    <p>Use the buttons on the right to move the graph or the ones in the middle to alter the scale. The buttons on the left can be used to alter the value of the parameter <i>a</i>. The two <i>inc</i> buttons alter the rate at which you can vary the parameter.</p>
+    <p>Click on the <strong>Curve</strong> menu to choose one of the associated curves. Then click on the diagram to choose a point for the involutes, pedal curve, etc. You can then move the point around and watch the associated curve change.</p>
+    <p>For the <strong>inverse</strong> (wrt a circle) click the mouse and drag to choose a centre and radius. You can then drag the centre of the circle<p>
+    <p>Use the buttons on the right to move the graph or the ones in the middle to alter the scale. The buttons on the left can be used to alter the value of the parameter <em>a</em>. The two <em>inc</em> buttons alter the rate at which you can vary the parameter.</p>
   </div>
 </div>
 

--- a/templates/plugins/oftheday.html
+++ b/templates/plugins/oftheday.html
@@ -116,7 +116,7 @@
     {% if numbigimages > 0 %}
     <a href="{{ '%s/@pictdisplay'|format(this.quote.person.path)|url }}">
     {% endif %}
-    <img class="biography-thumbnail" src="{{ thumbnail|url }}" />
+    <img class="biography-thumbnail" src="{{ thumbnail|url }}" alt="Thumbnail of {{ this.quote.person.shortname|e }}" />
     {% if numbigimages > 0 %}
     <br/>
     View {{ numbigimages|num2words }} larger picture{% if numbigimages > 1 %}s{% endif %}</a>

--- a/templates/plugins/oftheday.html
+++ b/templates/plugins/oftheday.html
@@ -87,7 +87,7 @@
         {{ page.deathyear|format_year }}:
         <a href="{{ page|url }}">{{ page.shortname }}</a>
         {% if page|has_died_poster %}
-        (<a href="{{ '%s/@poster/died'|format(page.path)|url }}">poster</a>)
+        (<a href="{{ '%s/@poster/died'|format(page.path)|url }}" aria-label="Poster of {{ page.shortname|e }}">poster</a>)
         {% endif %}
       </li>
     {% endfor %}

--- a/templates/plugins/pictdisplay.html
+++ b/templates/plugins/pictdisplay.html
@@ -48,7 +48,7 @@
   <div class="col-md-6">
   {% endif %}
 
-  <img src="{{ image|url }}"{% if image['height'] %} style="height: {{ image['height'] }}px"{% endif %} {% if image.description %}alt="{{ image.description|e }}" {% endif %}/>
+  <img src="{{ image|url }}"{% if image['height'] %} style="height: {{ image['height'] }}px"{% endif %} {% if image.alttext %}alt="{{ image.alttext|e }}" {% endif %}/>
   {% if image.description %}
   <p>{{ image.description }}</p>
   {% endif %}

--- a/templates/plugins/pictdisplay.html
+++ b/templates/plugins/pictdisplay.html
@@ -48,7 +48,7 @@
   <div class="col-md-6">
   {% endif %}
 
-  <img src="{{ image|url }}"{% if image['height'] %} style="height: {{ image['height'] }}px"{% endif %} />
+  <img src="{{ image|url }}"{% if image['height'] %} style="height: {{ image['height'] }}px"{% endif %} {% if image.description %}alt="{{ image.description|e }}" {% endif %}/>
   {% if image.description %}
   <p>{{ image.description }}</p>
   {% endif %}

--- a/templates/plugins/pictureindex.html
+++ b/templates/plugins/pictureindex.html
@@ -23,7 +23,7 @@
     {% if mathematician.has_pictdisplay %}
     <a href="{{ '%s/@pictdisplay'|format(mathematician.page.path)|url }}">
     {% endif %}
-      <img src="{{ mathematician.thumbnail|url }}" class="pictureindex-thumbnail" />
+      <img src="{{ mathematician.thumbnail|url }}" class="pictureindex-thumbnail" alt="Thumbnail of {{ mathematician.page.shortname|e }}" />
     {% if mathematician.has_pictdisplay %}
     </a>
     {% endif %}

--- a/templates/plugins/search.php
+++ b/templates/plugins/search.php
@@ -58,7 +58,7 @@ if ($mode === "") {
 <div class="row">
   <div class="col-md-12 col-md-offset-3 text-center">
     <form action="?" method="GET">
-      <input required name="query" type="text" accesskey="q" placeholder="Search">
+      <input required name="query" type="text" accesskey="q" placeholder="Search Query">
       <button type="submit">Search</button>
     </form>
   </div>
@@ -105,7 +105,7 @@ if ($mode === "query") {
 
       <!-- have the search box again -->
       <h6>Search Query</h6>
-      <input required name="query" type="text" accesskey="q" placeholder="Search" value="<?php echo $query_string; ?>" />
+      <input required name="query" type="text" accesskey="q" placeholder="Search" value="<?php echo $query_string; ?>" placeholder="Search Query" />
 
       <!-- allow choosing of what sections of the site to search -->
       <h6>Site Sections</h6>

--- a/templates/project.html
+++ b/templates/project.html
@@ -42,7 +42,7 @@
     {% endfor %}
     <ul>
     {% else %}
-    <i>Error: No chapters found</i>
+    <em>Error: No chapters found</em>
     {% endif %}
   </div>
 </div>

--- a/templates/projectsindex.html
+++ b/templates/projectsindex.html
@@ -27,7 +27,7 @@
     {% for page in site.query('/Projects') %}
       <li>
         <p>
-          <b><a href="{{ page|url }}">{{ page.title }}</a></b>
+          <strong><a href="{{ page|url }}">{{ page.title }}</strong></b>
           <br/>
           by {{ page.author }}
         </p>
@@ -35,7 +35,7 @@
     {% endfor %}
     <ul>
     {% else %}
-    <i>No projects found</i>
+    <em>No projects found</em>
     {% endif %}
   </div>
 </div>


### PR DESCRIPTION
Implement accessibility features for the site:
- add "skip to content" link on all pages that is hidden by default, but the first to be tabbed to
- add alt tags to majority of images (thumbnails, logo, )
- improve footer text contrast
- convert `<b>` and `<i>` to `<strong>` and `<em>` in templates
- add aria label to poster links on Of The Day pages
- add placeholder to search input field
- convert `<b>` and `<i>` to `<strong>` and `<em>` in content, during render stage
- increase contrast of translation symbol and other text colours
- add light grey underline to links
- make quotations source text colour black to improve contrast
- add alt text field to pictdisplay images, with defaults
- add alt text field for diagram images, with defaults

Other improvements/fixes:
- correct footer Maths department link
- remove duplicate "alphabetical-index-jumpbox" ID from biography index page
- fix nesting of DIVs in biography page
- change styling of quotations to move source out of styled block