### PR TITLE
add ARIA role of navigation to navbar

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -65,7 +65,7 @@
     <!-- END HEADER -->
 
     <!-- NAVIGATION -->
-    <div class="container nav-bar">
+    <div class="container nav-bar" role="navigation">
       <div class="row nav">
         {% for href, title in [
           ['/', 'Home'],


### PR DESCRIPTION
Accessibility guideline 1.3.1 (Info and Relationships) states that all content on the page should either be in either a HTML5 or WAI-ARIA landmark. Currently, the navigation bar is not included in one of these, and this PR adds a ARIA `navigation` role.