### PR TITLE
Various fixes

### DIFF
--- a/assets/static/js/extras-popup.js
+++ b/assets/static/js/extras-popup.js
@@ -37,7 +37,7 @@ for (var i = 0; i < links.length; i++) {
   if (! (isExtraLink || isPictdisplayLink)) continue
   link.onclick = function (link, isPictdisplay, e) {
     var width = 600
-    if (isPictdisplay) width = 768
+    if (isPictdisplay) width = 868
     var href = link.href
     extraLinkPopup(href, width)
     e.preventDefault()

--- a/packages/mathshistory-daily/setup.py
+++ b/packages/mathshistory-daily/setup.py
@@ -25,7 +25,7 @@ setup(
     packages=find_packages(),
     py_modules=['lektor_mathshistory_daily'],
     url='https://github.com/mathshistory/mathshistory-daily',
-    version='0.4.1',
+    version='0.4.2',
     classifiers=[
         'Framework :: Lektor',
         'Environment :: Plugins',

--- a/packages/mathshistory-renderer/lektor_mathshistory_renderer.py
+++ b/packages/mathshistory-renderer/lektor_mathshistory_renderer.py
@@ -262,7 +262,9 @@ def extrarender(match, record):
         return ''
     href = extra['link'].strip()
     href = correct_link(href, record)
-    return '<a class="elink" href="%s" target="_blank">THIS LINK</a>' % href
+    aria_label = extra['text'].__html__().unescape().strip()
+    aria_label = html.escape(aria_label, quote=True)
+    return '<a class="elink" href="%s" target="_blank" aria-label="%s">THIS LINK</a>' % (href, aria_label)
 
 def referencerender(match, record):
     number = match.group('number')

--- a/templates/plugins/oftheday.html
+++ b/templates/plugins/oftheday.html
@@ -72,7 +72,7 @@
         {{ page.birthyear|format_year }}:
         <a href="{{ page|url }}">{{ page.shortname }}</a>
         {% if page|has_born_poster %}
-        (<a href="{{ '%s/@poster/born'|format(page.path)|url }}">poster</a>)
+        (<a href="{{ '%s/@poster/born'|format(page.path)|url }}" aria-label="Poster of {{ page.shortname|e }}">poster</a>)
         {% endif %}
       </li>
     {% endfor %}


### PR DESCRIPTION
- Increase width of PictDisplay window popups by 100px so that side by side images show correctly
- Add `aria-label` attributes to extra links which have link text of `THIS LINK`
- Add `aria-label` attributes to born poster links on Mathematician Of The Day pages