### PR TITLE
Styling fix for headings

### DIFF
--- a/assets/static/css/content.css
+++ b/assets/static/css/content.css
@@ -1,12 +1,16 @@
 /* css rules for the bbcode content that is converted into HTML */
 
+.markup h2, .markup h3, .markup h4, .markup h5, .markup h6 {
+  margin-top: 1rem;
+}
+
 /* numbers, round brackets, square brackets, curly brackets */
-.non-italic {
+.markup .non-italic {
   font-style: normal;
 }
 
 /* [quote]...[/quote] */
-blockquote {
+.markup blockquote {
   background: #f9f9f9;
   border-left: 10px solid #ccc;
   margin-top: 0.7em;
@@ -17,7 +21,7 @@ blockquote {
   font-style: italic;
   text-align: justify;
 }
-blockquote:before {
+.markup blockquote:before {
   color: #ccc;
   font-size: 4em;
   line-height: 0.1em;
@@ -25,97 +29,97 @@ blockquote:before {
 }
 
 /* [center]...[/center] */
-.center-paragraph {
+.markup .center-paragraph {
   text-align: center;
 }
 
 /* [ind]...[/ind] */
-.indent-paragraph {
+.markup .indent-paragraph {
   /* directly from hypercard */
   margin: 1em 0 1em 40px;
 }
 
 /* [ovl]...[/ovl] */
-.overline {
+.markup .overline {
   text-decoration: overline;
 }
 
 /* [sub]...[/sub] */
-.subscript {
+.markup .subscript {
   vertical-align: sub;
 }
 
 /* [sup]...[/sup] */
-.superscript {
+.markup .superscript {
   vertical-align: super;
 }
 
 /* [gl]...[/gl] */
-.gllink {
+.markup .gllink {
   color: #008000;
 }
 
 /* [ac]...[/ac] */
-.aclink {
+.markup .aclink {
   color: brown;
 }
 
 /* [big]...[/big] */
-.bigger {
+.markup .bigger {
   font-size: larger;
 }
 
 /* [small]...[/small] */
-.smaller {
+.markup .smaller {
   font-size: smaller;
 }
 
 /* [t]...[/t] */
-.translation {
+.markup .translation {
   color: #EB0000 !important;
   cursor: pointer;
 }
 
-.katex {
+.markup .katex {
   font-size: 1em !important;
 }
 
-.blue-block {
+.markup .blue-block {
   background-color: #ccffff;
   padding: 10px;
 }
 
-.grey-block {
+.markup .grey-block {
   background-color: #cccccc;
   padding: 10px;
 }
 
-table {
+.markup table {
   width: 100%;
 }
 
-.math-error {
+.markup .math-error {
   color: #EB0000;
 }
 
-.red-text {
+.markup .red-text {
   color: #EB0000;
 }
-.blue-text {
+.markup .blue-text {
   color: blue;
 }
-.green-text {
+.markup .green-text {
   color: #008000;
 }
-.brown-text {
+.markup .brown-text {
   color: brown;
 }
 
-.diagram {
+.markup .diagram {
   border: none;
   margin: 5px 0 5px 10px;
 }
 
-pre {
+.markup pre {
   margin-top: 1rem;
 }

--- a/assets/static/css/site.css
+++ b/assets/static/css/site.css
@@ -12,9 +12,6 @@ h1, h2, h3, h4, h5, h6, ol, ul {
   letter-spacing: initial;
   text-transform: initial;
 }
-h2, h3, h4, h5, h6 {
-  margin-top: 1rem;
-}
 .container {
   background-color: #FFFFFF;
 }

--- a/packages/mathshistory-renderer/lektor_mathshistory_renderer.py
+++ b/packages/mathshistory-renderer/lektor_mathshistory_renderer.py
@@ -220,7 +220,7 @@ def render(source, record):
         html_formula = html_array[idx]
         source = source.replace(key, html_formula)
 
-    return source
+    return '<span class="markup">\n%s\n</span>' % source
 
 
 

--- a/packages/mathshistory-renderer/setup.py
+++ b/packages/mathshistory-renderer/setup.py
@@ -26,7 +26,7 @@ setup(
     install_requires=['beautifulsoup4','html5lib','regex'],
     py_modules=['lektor_mathshistory_renderer'],
     url='https://github.com/mathshistory/mathshistory-renderer',
-    version='0.4.14',
+    version='0.4.15',
     classifiers=[
         'Framework :: Lektor',
         'Environment :: Plugins',


### PR DESCRIPTION
A previous commit added top margins to h2,h3,h4,h5,h6 site wide. This made the markup content look much better, but had a negative impact to other areas of the site. This PR fixes this by wrapping the rendered markup in a `<span class="markup">...</span>` so it can be styled independently to the rest of the site, and then moves the CSS rule to only apply to markup headings.