### PR TITLE
remove whitespace from start/end of rendered text, fixes #261

### DIFF
--- a/packages/mathshistory-renderer/lektor_mathshistory_renderer.py
+++ b/packages/mathshistory-renderer/lektor_mathshistory_renderer.py
@@ -220,7 +220,7 @@ def render(source, record):
         html_formula = html_array[idx]
         source = source.replace(key, html_formula)
 
-    return '<span class="markup">\n%s\n</span>' % source
+    return '<span class="markup">%s</span>' % source
 
 
 

--- a/packages/mathshistory-renderer/setup.py
+++ b/packages/mathshistory-renderer/setup.py
@@ -26,7 +26,7 @@ setup(
     install_requires=['beautifulsoup4','html5lib','regex'],
     py_modules=['lektor_mathshistory_renderer'],
     url='https://github.com/mathshistory/mathshistory-renderer',
-    version='0.4.15',
+    version='0.4.16',
     classifiers=[
         'Framework :: Lektor',
         'Environment :: Plugins',


### PR DESCRIPTION
Removes the `\n` from the start/end of the rendered markup, to remove the extra incorrect whitespace of popups